### PR TITLE
fix incorrect var { } syntax in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Typical usage:
 	cmdFlag := getopt.StringLong("command", 'c', "default", "the command)
 
 	Declare flags against existing variables.
-	var {
+	var (
 		fileName = "/the/default/path"
 		timeout = time.Second * 5
 		verbose bool
-	}
+	)
 	func init() {
 		getopt.Flag(&verbose, 'v', "be verbose")
 		getopt.FlagLong(&fileName, "path", 0, "the path")


### PR DESCRIPTION
Fix the example in the README which incorrectly uses
curly brackets for var declaration, it should use parenthesis.

Signed-off-by: Jeremiah Mahler <jmmahler@gmail.com>