### PR TITLE
Put GoDoc link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # getopt
 
+[![GoDoc](https://godoc.org/github.com/pborman/getopt?status.svg)](https://godoc.org/github.com/pborman/getopt)
+
 Package getopt provides traditional getopt processing for implementing
 commands that use traditional command lines.  The standard Go flag package
 cannot be used to write a program that parses flags the way ls or ssh does,


### PR DESCRIPTION
It's a cool library.
Therefore I think that it should be more known to the world.
For the first time, would you put "GoDoc" link on top of the `README.md`?