### PR TITLE
Add module files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/pborman/getopt
+
+go 1.12

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,0 +1,3 @@
+module github.com/pborman/getopt/v2
+
+go 1.12


### PR DESCRIPTION
Allow both github.com/pborman/getopt and github.com/pborman/getopt/v2 to
be recognized by go as modules.

I believe this is the minimal setup required. Without any `go.mod` files, attempting to use getopt as a module with `import getopt "github.com/pborman/getopt/v2"` results in:
```
% go build
go: finding github.com/pborman/getopt/v2 latest
go: downloading github.com/pborman/getopt/v2 v2.0.0-20190409184431-ee0cd42419d3
build github.com/sam-github/git-walk: cannot load github.com/pborman/getopt/v2: cannot find module providing package github.com/pborman/getopt/v2
```
When I put module files in my fork (same as the files I'm PRing here, but with "sam-github" instead of "pborman"), this is the result:
```
% go build
go: finding github.com/sam-github/getopt/v2 latest
go: downloading github.com/sam-github/getopt/v2 v2.0.0-20190711204637-6fff65b44356
go: extracting github.com/sam-github/getopt/v2 v2.0.0-20190711204637-6fff65b44356
```

I think this is the minimal setup to support automatic recognition as a module, and that they don't have any effect on existing users.