### PR TITLE
Option interface help message getter to allow for custom formatting.

### DIFF
--- a/v2/help_test.go
+++ b/v2/help_test.go
@@ -143,3 +143,38 @@ func TestHelpDefaults(t *testing.T) {
 		t.Errorf("got:\n%s\nwant:\n%s", got, want)
 	}
 }
+
+func TestHelpString(t *testing.T) {
+
+	set := New()
+
+	descriptions := []string{
+		"test description",
+		"",
+		"💣💣",
+	}
+
+	testOption := func(t *testing.T, o Option, expected string) {
+		if o == nil {
+			t.Fatal("could not find option")
+		}
+
+		actual := o.Help()
+
+		if actual != expected {
+			t.Error("got", actual, "expected", expected)
+		}
+	}
+
+	for i, expected := range descriptions {
+
+		long := fmt.Sprintf("test%d", i)
+		short := rune('a' + i)
+
+		set.FlagLong(&i, long, short, expected)
+
+		testOption(t, set.Lookup(long), expected)
+
+		testOption(t, set.Lookup(short), expected)
+	}
+}

--- a/v2/option.go
+++ b/v2/option.go
@@ -25,6 +25,10 @@ type Option interface {
 	// is no long name.  The name does not include the "--".
 	LongName() string
 
+	// Help always returns a description of the option, or "" if there
+	// is no description.
+	Help() string
+
 	// IsFlag returns true if Option is a flag.
 	IsFlag() bool
 
@@ -151,6 +155,10 @@ func (o *option) ShortName() string {
 
 func (o *option) LongName() string {
 	return o.long
+}
+
+func (o *option) Help() string {
+	return o.help
 }
 
 // Reset rests an option so that it appears it has not yet been seen.


### PR DESCRIPTION
Pretty simple change.  Just had a need to have a different format that PrintOptions and was missing the help text.