### PR TITLE
Fix non-constant Fprintf format strings

### DIFF
--- a/v2/var.go
+++ b/v2/var.go
@@ -92,7 +92,7 @@ func (s *Set) addFlag(p Value, name string, short rune, helpvalue ...string) Opt
 		opt.where = where
 	}
 	if opt.short == 0 && opt.long == "" {
-		fmt.Fprintf(stderr, opt.where+": no short or long option given")
+		fmt.Fprint(stderr, opt.where+": no short or long option given")
 		exit(1)
 	}
 	s.AddOption(opt)

--- a/var.go
+++ b/var.go
@@ -55,7 +55,7 @@ func (s *Set) VarLong(p Value, name string, short rune, helpvalue ...string) Opt
 		opt.where = fmt.Sprintf("%s:%d", file, line)
 	}
 	if opt.short == 0 && opt.long == "" {
-		fmt.Fprintf(stderr, opt.where+": no short or long option given")
+		fmt.Fprint(stderr, opt.where+": no short or long option given")
 		exit(1)
 	}
 	s.AddOption(opt)


### PR DESCRIPTION
This fixes two calls where a fully assembled message is passed as the format argument to fmt.Fprintf. Recent Go vet versions report these as non-constant format strings.

The strings are already constructed by concatenation and do not use formatting directives, so fmt.Fprint is the simpler and safer call. The same fix is applied to both the root module and the v2 module.

Validation:
- go test ./...